### PR TITLE
Add find_all_by_city method to do reverse lookup on IATA

### DIFF
--- a/lib/airports.rb
+++ b/lib/airports.rb
@@ -14,8 +14,8 @@ module Airports
   end
   
   def self.find_all_by_city(city)
-    airport_data = parsed_data.values.find_all { |d| d["city"].downcase == city.downcase }
-    return airport_data
+    airports = parsed_data.values.find_all { |d| d["city"].downcase == city.downcase }
+    return airports
   end
 
   def self.find_by_icao_code(icao_code)

--- a/lib/airports.rb
+++ b/lib/airports.rb
@@ -15,7 +15,10 @@ module Airports
   
   def self.find_by_city(city)
     return unless city.length < 1
-    airport_data = parsed_data.fetch(city, nil)
+
+    airport_data = parsed_data.values.find do |data|
+      data["city"] == city
+    end
 
     return unless airport_data
 

--- a/lib/airports.rb
+++ b/lib/airports.rb
@@ -13,17 +13,9 @@ module Airports
       new(airport_data.each_with_object({}) { |(k, v), h| h[k.to_sym] = v })
   end
   
-  def self.find_by_city(city)
-    return unless city.length < 1
-
-    airport_data = parsed_data.values.find do |data|
-      data["city"] == city
-    end
-
-    return unless airport_data
-
-    Airport.
-      new(airport_data.each_with_object({}) { |(k, v), h| h[k.to_sym] = v })
+  def self.find_all_by_city(city)
+    airport_data = parsed_data.values.find_all { |d| d["city"].downcase == city.downcase }
+    return airport_data
   end
 
   def self.find_by_icao_code(icao_code)

--- a/lib/airports.rb
+++ b/lib/airports.rb
@@ -14,8 +14,7 @@ module Airports
   end
   
   def self.find_all_by_city(city)
-    airports = parsed_data.values.find_all { |d| d["city"].downcase == city.downcase }
-    return airports
+    parsed_data.values.find_all { |d| d["city"].downcase == city.downcase }
   end
 
   def self.find_by_icao_code(icao_code)

--- a/lib/airports.rb
+++ b/lib/airports.rb
@@ -12,6 +12,16 @@ module Airports
     Airport.
       new(airport_data.each_with_object({}) { |(k, v), h| h[k.to_sym] = v })
   end
+  
+  def self.find_by_city(city)
+    return unless city.length < 1
+    airport_data = parsed_data.fetch(city, nil)
+
+    return unless airport_data
+
+    Airport.
+      new(airport_data.each_with_object({}) { |(k, v), h| h[k.to_sym] = v })
+  end
 
   def self.find_by_icao_code(icao_code)
     return unless icao_code.length == 4


### PR DESCRIPTION
This method is useful in any case where you would want to grab `iata` code by the city name

would return `nil` if no airport found and an `array` of airports if found.  It should be up to users to whatever they want to do with the returned data.

In my case, I filter out returned list of airports and if no international airport found then typically it would be only one airport in that city.