### PR TITLE
Support looking airports by city name with `Airports.find_all_by_city_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.5.0 (5 December 2019)
+
+* Support looking up airports by the name of the city they
+are located in with `Airports.find_all_by_city_name` (@viral810, @timrogers)
+* Refactor `Airports` so `Airport` objects are only generated once
+and the code is cleaner (@timrogers)
+
 # v1.4.1 (14 November 2019)
 
 * Correct the time zone of Istanbul Airport (`IST`) (@aliismayilov)

--- a/lib/airports.rb
+++ b/lib/airports.rb
@@ -8,25 +8,13 @@ module Airports
   def self.find_by_iata_code(iata_code)
     return unless iata_code.length == 3
 
-    airport_data = parsed_data.fetch(iata_code, nil)
-
-    return unless airport_data
-
-    Airport.
-      new(airport_data.each_with_object({}) { |(k, v), h| h[k.to_sym] = v })
+    all.find { |airport| airport.iata == iata_code }
   end
 
   def self.find_by_icao_code(icao_code)
     return unless icao_code.length == 4
 
-    airport_data = parsed_data.values.find do |data|
-      data["icao"] == icao_code
-    end
-
-    return unless airport_data
-
-    Airport.
-      new(airport_data.each_with_object({}) { |(k, v), h| h[k.to_sym] = v })
+    all.find { |airport| airport.icao == icao_code }
   end
 
   def self.iata_codes
@@ -34,15 +22,24 @@ module Airports
   end
 
   def self.all
-    @all ||= parsed_data.map do |_iata_code, airport_data|
-      Airport.
-        new(airport_data.each_with_object({}) { |(k, v), h| h[k.to_sym] = v })
+    @all ||= parsed_data.values.map do |airport_data|
+      airport_from_parsed_data_element(airport_data)
     end
   end
 
   def self.parsed_data
     @parsed_data ||= JSON.parse(data)
   end
+
+  def self.airport_from_parsed_data_element(parsed_data_element)
+    # TODO: Once we're using Ruby 2.5+, use Hash#transform_keys here to symbolize the keys
+    transformed_hash = parsed_data_element.each_with_object({}) do |(k, v), hash|
+      hash[k.to_sym] = v
+    end
+
+    Airport.new(transformed_hash)
+  end
+  private_class_method :airport_from_parsed_data_element
 
   def self.data
     @data ||= File.read(data_path)

--- a/lib/airports.rb
+++ b/lib/airports.rb
@@ -17,6 +17,10 @@ module Airports
     all.find { |airport| airport.icao == icao_code }
   end
 
+  def self.find_all_by_city_name(city_name)
+    all.select { |airport| airport.city.casecmp(city_name).zero? }
+  end
+
   def self.iata_codes
     parsed_data.keys
   end

--- a/lib/airports/version.rb
+++ b/lib/airports/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Airports
-  VERSION = "1.4.1"
+  VERSION = "1.5.0"
 end

--- a/spec/airports_spec.rb
+++ b/spec/airports_spec.rb
@@ -70,10 +70,31 @@ RSpec.describe Airports do
     context "with a code that is too long" do
       let(:icao_code) { "ALICE" }
 
-      it "doesn't try to look it up" do
-        expect(described_class.parsed_data).to_not receive(:fetch).with(icao_code, nil)
-        find_by_icao_code
-      end
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe ".find_all_by_city_name" do
+    subject(:find_all_by_city_name) do
+      described_class.find_all_by_city_name(city_name)
+    end
+
+    context "with a city name that has matches" do
+      let(:city_name) { "London" }
+
+      its(:length) { is_expected.to eq(7) }
+    end
+
+    context "with a city name that has matches, apart from case" do
+      let(:city_name) { "lOnDoN" }
+
+      its(:length) { is_expected.to eq(7) }
+    end
+
+    context "with a non-matching city name" do
+      let(:city_name) { "Asgard" }
+
+      it { is_expected.to be_empty }
     end
   end
 end


### PR DESCRIPTION
Fixes #7.

I've used the idea of a "city name" to avoid confusion, as one might expect to see IATA city codes.

This PR also refactors `Airports` to generate `Airport` objects more neatly and only do it once, rather than for each lookup.