### PR TITLE
Fix ruby 2.7 warning

### DIFF
--- a/lib/airports.rb
+++ b/lib/airports.rb
@@ -41,7 +41,7 @@ module Airports
       hash[k.to_sym] = v
     end
 
-    Airport.new(transformed_hash)
+    Airport.new(**transformed_hash)
   end
   private_class_method :airport_from_parsed_data_element
 


### PR DESCRIPTION
The actual message from ruby interpreter:
```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```