### PR TITLE
Add find_all_by_country_name method

### DIFF
--- a/lib/airports.rb
+++ b/lib/airports.rb
@@ -21,6 +21,10 @@ module Airports
     all.select { |airport| airport.city.casecmp(city_name).zero? }
   end
 
+  def self.find_all_by_country_name(country_name)
+    all.select { |airport| airport.country.casecmp(country_name).zero? }
+  end
+
   def self.iata_codes
     parsed_data.keys
   end

--- a/spec/airports_spec.rb
+++ b/spec/airports_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Airports do
     end
 
     context "with a country name that has matches, apart from case" do
-      let(:country_name) { "DOMinICan rEpUBliC"}
+      let(:country_name) { "DOMinICan rEpUBliC" }
 
       its(:length) { is_expected.to eq(11) }
     end

--- a/spec/airports_spec.rb
+++ b/spec/airports_spec.rb
@@ -115,4 +115,28 @@ RSpec.describe Airports do
       it { is_expected.to be_empty }
     end
   end
+
+  describe ".find_all_by_country_name" do
+    subject(:find_all_by_country_name) do
+      described_class.find_all_by_country_name(country_name)
+    end
+
+    context "with a country name that has matches" do
+      let(:country_name) { "Dominican Republic" }
+
+      its(:length) { is_expected.to eq(11) }
+    end
+
+    context "with a country name that has matches, apart from case" do
+      let(:country_name) { "DOMinICan rEpUBliC"}
+
+      its(:length) { is_expected.to eq(11) }
+    end
+
+    context "with a non-matching country name" do
+      let(:country_name) { "XYZabc" }
+
+      its(:length) { is_expected.to eq(0) }
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a `find_all_by_country_name` method to filter airports by country.