### PR TITLE
Add Class Method for ICAO Codes 

### DIFF
--- a/lib/airports.rb
+++ b/lib/airports.rb
@@ -29,6 +29,10 @@ module Airports
     parsed_data.keys
   end
 
+  def self.icao_codes
+    parsed_data.values.map { |airport_data| airport_data["icao"] }
+  end
+
   def self.all
     @all ||= parsed_data.values.map do |airport_data|
       airport_from_parsed_data_element(airport_data)

--- a/spec/airports_spec.rb
+++ b/spec/airports_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe Airports do
     it { is_expected.to include("LHR") }
   end
 
+  describe ".icao_codes" do
+    subject { described_class.icao_codes }
+
+    it { is_expected.to be_a(Array) }
+    it { is_expected.to include("EGLL") }
+  end
+
   describe ".all" do
     subject { described_class.all }
 


### PR DESCRIPTION
This copies @FinnLawrence's great work in https://github.com/timrogers/airports/pull/135, rebased on `main` to get the tests passing.

### Changes

- Add new `icao_codes` class method to return ICAO codes for airports, equivalent with `Aiports.iata_codes`.
- Add spec for new method.