### PR TITLE
Add Chengdu Tianfu International Airport (IATA: TFU, ICAO: ZUTF)

### DIFF
--- a/data/patches.dat
+++ b/data/patches.dat
@@ -9,3 +9,4 @@
 99997,"Monmouth Executive Airport","Belmar-Farmingdale","United States","BLM","KBLM",40.186667,-74.124444,153,-5,"A","America/New_York","airport","OurAirports"
 99998,"Kertajati International Airport","Majalengka","Indonesia","KJT","WICA",-6.6519467,108.1551111,36,7,"N","Asia/Jakarta","airport","OurAirports"
 99999,"Felipe Carrillo Puerto International Airport","Tulum","Mexico","TQO","MMTL",20.1662,-87.6592,66,"S","America/Cancun","airport","OurAirports"
+99995,"Chengdu Tianfu International Airport","Chengdu","China","TFU","ZUTF",30.3133,104.4447,1476,8,"U","Asia/Shanghai","airport","OurAirports"


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Chengdu_Tianfu_International_Airport